### PR TITLE
Apply fixes required due to MonadFail

### DIFF
--- a/src/Data/SExpresso/Language/SchemeR5RS.hs
+++ b/src/Data/SExpresso/Language/SchemeR5RS.hs
@@ -74,6 +74,7 @@ module Data.SExpresso.Language.SchemeR5RS (
 
   ) where
 
+import Control.Monad (mzero)
 import Data.Maybe
 import Data.Proxy
 import Data.List
@@ -471,7 +472,7 @@ ureal r s = dotN <|> ureal'
   where dotN =  do
           _ <- char '.'
           if r /= R10
-          then fail "Numbers containing decimal point must be in decimal radix"
+          then label "Numbers containing decimal point must be in decimal radix" mzero
           else do
              n <- uinteger R10
              sf <- optional suffix
@@ -495,14 +496,14 @@ ureal r s = dotN <|> ureal'
             case sf of
               Just _ -> return $ SDecimal s u1 (UInteger 0) sf
               Nothing -> return $ SInteger s u1
-        
+
         rational u1 = do
           u2 <- uinteger r
           return $ SRational s u1 u2
 
         decimal u1 = do
           if r /= R10
-          then fail "Numbers containing decimal point must be in decimal radix"
+          then label "Numbers containing decimal point must be in decimal radix" mzero
           else do
              -- If u1 has # character, only other # are
              -- allowed. Otherwise a number may be present

--- a/src/Data/SExpresso/Parse/Generic.hs
+++ b/src/Data/SExpresso/Parse/Generic.hs
@@ -61,6 +61,7 @@ module Data.SExpresso.Parse.Generic
 import Data.Maybe
 import qualified Data.Map as M
 import Control.Applicative
+import Control.Monad (mzero)
 import Text.Megaparsec
 import Data.SExpresso.SExpr
 import Data.SExpresso.Parse.Location
@@ -270,8 +271,8 @@ sepEndBy1' p sep f = do
               then do
                 xs <- parseContent a2
                 return $ a2 : xs
-              else fail ("The previous two atoms are not separated by space.\n" ++
-                         "A space was expected at " ++ sourcePosPretty (fromJust mpos))
+              else label ("The previous two atoms are not separated by space.\n" <>
+                         "A space was expected at " <> sourcePosPretty (fromJust mpos)) mzero
 
 -- | The 'parseSExprList' function return a parser for parsing S-expression of the form @'SList' _ _@.
 parseSExprList :: (MonadParsec e s m) =>


### PR DESCRIPTION
Since `MonadFail` was accepted `fail` is no longer part of `Monad` and
hence not part of `MonadParsec` so it cannot be used to trigger parser
failures. The places where `fail` was used fail parsing were replaced by
`label "the error message" mzero` which I gives you the same affect,
failing parsing with a custom string message while keeping the error
type polymorphic.

Test suite runs successfully NiXOS Linux with GHC 8.8.1 and the following packages:  
```
StateVar ==1.2,
ansi-terminal ==0.9.1,
ansi-wl-pprint ==0.6.9,
array ==0.5.4.0,
async ==2.2.2,
base ==4.13.0.0,
base-orphans ==0.8.1,
bifunctors ==5.5.5,
binary ==0.8.7.0,
bytestring ==0.10.9.0,
call-stack ==0.1.0,
case-insensitive ==1.2.0.11,
clock ==0.8,
colour ==2.3.5,
comonad ==5.0.5,
containers ==0.6.2.1,
contravariant ==1.5.2,
deepseq ==1.4.4.0,
directory ==1.3.3.2,
distributive ==0.6,
exceptions ==0.10.3,
filepath ==1.4.2.1,
free ==5.1.2,
ghc-boot-th ==8.8.1,
ghc-prim ==0.5.3,
hashable ==1.2.7.0,
integer-gmp ==1.0.2.0,
integer-logarithms ==1.0.3,
logict ==0.7.0.2,
megaparsec ==7.0.5,
mtl ==2.2.2,
optparse-applicative ==0.15.1.0,
parser-combinators ==1.1.0,
pretty ==1.1.3.6,
primitive ==0.6.4.0,
process ==1.6.5.1,
profunctors ==5.3,
recursion-schemes ==5.1.3,
rts ==1.0,
scientific ==0.3.6.2,
semigroupoids ==5.3.3,
semigroups ==0.18.5,
smallcheck ==1.1.5,
stm ==2.5.0.0,
tagged ==0.8.6,
tasty ==1.2.3,
tasty-hunit ==0.10.0.2,
tasty-smallcheck ==0.8.1,
template-haskell ==2.15.0.0,
text ==1.2.4.0,
th-abstraction ==0.3.1.0,
time ==1.9.3,
transformers ==0.5.6.2,
transformers-base ==0.4.5.2,
transformers-compat ==0.6.5,
unbounded-delays ==0.1.1.0,
unix ==2.7.2.2,
unordered-containers ==0.2.10.0,
wcwidth ==0.0.2
```