### PR TITLE
Support recursion-schemes-5.2

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
 - megaparsec >= 7.0 && <= 8.0.0
 - containers >= 0.5 && < 0.7
 - bifunctors >= 5.5 && < 5.6
-- recursion-schemes >= 5.1 && < 5.2
+- recursion-schemes >= 5.1 && < 5.3
 
 library:
   source-dirs: src


### PR DESCRIPTION
Sexpresso builds with recursion-schemes-5.2 with no problems.